### PR TITLE
Proper label for dns service ip on network tab

### DIFF
--- a/helper/src/components/networkTab.js
+++ b/helper/src/components/networkTab.js
@@ -195,7 +195,7 @@ function PodServiceNetwork({ net, updateFn }) {
                 <MessageBar messageBarType={MessageBarType.warning}>Address space that isn't in use elsewhere in your network environment <a target="_target" href="https://docs.microsoft.com/en-us/azure/aks/configure-kubenet#create-an-aks-cluster-in-the-virtual-network">docs</a></MessageBar>
             </Stack.Item>
             <Stack.Item styles={{root: {width: '380px'}}} align="start">
-                <TextField prefix="IP" label="Service Network" onChange={(ev, val) => updateFn("dnsServiceIP", val)} value={net.dnsServiceIP} />
+                <TextField prefix="IP" label="DNS Service IP" onChange={(ev, val) => updateFn("dnsServiceIP", val)} value={net.dnsServiceIP} />
                 <MessageBar messageBarType={MessageBarType.warning}>Ensure its an address within the Service CIDR above <a target="_target" href="https://docs.microsoft.com/en-us/azure/aks/configure-kubenet#create-an-aks-cluster-in-the-virtual-network">docs</a></MessageBar>
             </Stack.Item>
 


### PR DESCRIPTION
## PR Summary

<!-- summarize your PR between here and complete the checklist with 'x' between the brackets -->
Very minor fix in helper - change second "Service Network" label to "DNS Service IP".

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [ ] Link to a filed issue
